### PR TITLE
Unlocks the zookeeper notifier lock when the session expires

### DIFF
--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -326,6 +326,11 @@ func (nc *Coordinator) manageEvalLoop() {
 		for !nc.App.ZookeeperConnected {
 			time.Sleep(100 * time.Millisecond)
 		}
+
+		err := lock.Unlock()
+		if err != nil {
+			panic("Unable to release zookeeper lock after session expiration")
+		}
 	}
 }
 

--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -327,7 +327,7 @@ func (nc *Coordinator) manageEvalLoop() {
 			time.Sleep(100 * time.Millisecond)
 		}
 
-		err := lock.Unlock()
+		err = lock.Unlock()
 		if err != nil {
 			panic("Unable to release zookeeper lock after session expiration")
 		}

--- a/core/internal/notifier/coordinator_race_test.go
+++ b/core/internal/notifier/coordinator_race_test.go
@@ -13,6 +13,8 @@
 package notifier
 
 import (
+	"errors"
+	"sync/atomic"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -119,14 +121,32 @@ func TestCoordinator_manageEvalLoop_Expiration(t *testing.T) {
 	assert.False(t, coordinator.doEvaluations, "Expected doEvaluations to be false")
 }
 
+type statefulMockLock struct {
+	*helpers.MockZookeeperLock
+	lockHeld *int32
+}
+
+func (s *statefulMockLock) Lock() error {
+	if atomic.CompareAndSwapInt32(s.lockHeld, 0, 1) {
+		return nil
+	}
+	return errors.New("unable to lock twice: must unlock first")
+}
+
+func (s *statefulMockLock) Unlock() error {
+	if atomic.CompareAndSwapInt32(s.lockHeld, 1, 0) {
+		return nil
+	}
+	return errors.New("unable to unlock: lock not held")
+}
+
 // We know this will trigger the race detector, because of the way we manipulate the ZK state
 func TestCoordinator_manageEvalLoop_Reconnect(t *testing.T) {
 	coordinator := fixtureCoordinator()
 	coordinator.Configure()
 
 	// Add mock calls for the Zookeeper client - Lock immediately returns with no error
-	mockLock := &helpers.MockZookeeperLock{}
-	mockLock.On("Lock").Return(nil)
+	mockLock := &statefulMockLock{&helpers.MockZookeeperLock{}, new(int32)}
 	mockZk := coordinator.App.Zookeeper.(*helpers.MockZookeeperClient)
 	mockZk.On("NewLock", "/burrow/notifier").Return(mockLock)
 


### PR DESCRIPTION
In staging we were seeing the following logs:

```
01:30:43
{"level":"info","ts":1563845443.5814512,"msg":"Recv loop terminated: err=EOF","type":"coordinator","name":"zookeeper"}
01:30:43
{"level":"info","ts":1563845443.5814893,"msg":"Send loop terminated: err=<nil>","type":"coordinator","name":"zookeeper"}
01:30:43
{"level":"info","ts":1563845443.582324,"msg":"Connected to 10.2.1.121:2181","type":"coordinator","name":"zookeeper"}
01:30:43
{"level":"info","ts":1563845443.58583,"msg":"Authentication failed: zk: session has been expired by the server","type":"coordinator","name":"zookeeper"}
01:30:43
{"level":"error","ts":1563845443.5859132,"msg":"session expired","type":"coordinator","name":"zookeeper"}
01:30:43
{"level":"info","ts":1563845443.5859392,"msg":"stopping evaluations","type":"coordinator","name":"notifier"}
01:30:43
{"level":"info","ts":1563845443.5867062,"msg":"Connected to 10.2.3.153:2181","type":"coordinator","name":"zookeeper"}
01:30:43
{"level":"info","ts":1563845443.5867276,"msg":"starting session","type":"coordinator","name":"zookeeper"}
01:30:43
{"level":"info","ts":1563845443.5914874,"msg":"Authenticated: id=144115271298973697, timeout=6000","type":"coordinator","name":"zookeeper"}
01:30:43
{"level":"info","ts":1563845443.5915,"msg":"Re-submitting `0` credentials after reconnect","type":"coordinator","name":"zookeeper"}
01:30:43
{"level":"warn","ts":1563845443.786129,"msg":"failed to get zk lock","type":"coordinator","name":"notifier","error":"zk: trying to acquire a lock twice"}
01:30:43
{"level":"warn","ts":1563845443.886231,"msg":"failed to get zk lock","type":"coordinator","name":"notifier","error":"zk: trying to acquire a lock twice"}
01:30:43
{"level":"warn","ts":1563845443.9863462,"msg":"failed to get zk lock","type":"coordinator","name":"notifier","error":"zk: trying to acquire a lock twice"}
01:30:44
{"level":"warn","ts":1563845444.0864675,"msg":"failed to get zk lock","type":"coordinator","name":"notifier","error":"zk: trying to acquire a lock twice"}
01:30:44
{"level":"warn","ts":1563845444.1865752,"msg":"failed to get zk lock","type":"coordinator","name":"notifier","error":"zk: trying to acquire a lock twice"}
01:30:44
{"level":"warn","ts":1563845444.2866895,"msg":"failed to get zk lock","type":"coordinator","name":"notifier","error":"zk: trying to acquire a lock twice"}
01:30:44
{"level":"warn","ts":1563845444.3868032,"msg":"failed to get zk lock","type":"coordinator","name":"notifier","error":"zk: trying to acquire a lock twice"}
01:30:44
{"level":"warn","ts":1563845444.4869232,"msg":"failed to get zk lock","type":"coordinator","name":"notifier","error":"zk: trying to acquire a lock twice"}
01:30:44
{"level":"warn","ts":1563845444.5870247,"msg":"failed to get zk lock","type":"coordinator","name":"notifier","error":"zk: trying to acquire a lock twice"}
(repeat the above acquire log endlessly)
```

From what I can gather from issues https://github.com/linkedin/Burrow/issues/322 and https://github.com/linkedin/Burrow/issues/531, the `manageEvalLoop` function never released the lock to notify. Because of that, once the connection to zookeeper is re-established, we end up in a tight-loop trying to acquire a lock that can't ever be acquired.

In this PR, I've unlocked that lock after re-establishing a connection to zookeeper. Additionally, I've panicked if there is an error (if the container dies and restarts, it'll clear itself up because the lock is ephemeral).